### PR TITLE
Log Error if registries are in sysconfig

### DIFF
--- a/registries.c
+++ b/registries.c
@@ -19,6 +19,29 @@ GPtrArray* tmp_values;
 char * headers [] = { "registries", "insecure_registries", "block_registries" };
 gchar *cur_header = "None";
 
+/*
+ * Check if registries are still being exported from
+ * sysconfig
+ */
+void check_envs(){
+	char *env_variables[] = {
+			"ADD_REGISTRY",
+			"INSECURE_REGISTRY",
+			"BLOCK_REGISTRY",
+			0
+
+	};
+	for (char** p = env_variables; p; p++) {
+		if (getenv(*p) != NULL) {
+			fprintf(stderr, "Registry information should be stored in "
+					"/etc/containers/registries.conf and not in "
+					"/etc/sysconfig/docker\n");
+		}
+		break;
+	}
+
+
+}
 
 /*
  * Add  a single value to the tmp_array
@@ -245,6 +268,8 @@ int main(int argc, char *argv[])
 	// Global vars
 	hash = g_hash_table_new_full(g_str_hash, g_str_equal, NULL, NULL);
 	tmp_values = g_ptr_array_new();
+
+	check_envs();
 
 	static gboolean json = FALSE;
 	static gchar *input_file;

--- a/registries.service
+++ b/registries.service
@@ -4,6 +4,7 @@ Before=docker.service
 After=network.target
 
 [Service]
+EnvironmentFile=-/etc/sysconfig/docker
 Type=oneshot
 ExecStart=/usr/libexec/registries -o /run/containers/registries.conf -V REGISTRIES
 


### PR DESCRIPTION
To help users migrate their registries information from sysconfig to
/etc/containers/registries.conf, we now check to see if registry
information is still being exported.  If so, we write to stderr
so it is picked up in journalctl or syslog.