### PR TITLE
Add CFLAGS for RHEL

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -4,3 +4,5 @@ registries_SOURCES = registries.c
 registries_CFLAGS = $(REGISTRIES_DEPS_CFLAGS)
 registries_LDADD = $(REGISTRIES_DEPS_LIBS)
 TESTS = test/test.sh
+registries_CFLAGS += -std=gnu99
+

--- a/configure.ac
+++ b/configure.ac
@@ -16,4 +16,5 @@ AC_CHECK_PROG(GO_MD2MAN_CHECK,go-md2man,yes)
 if test x"$GO_MD2MAN_CHECK" != x"yes" ; then
     AC_MSG_ERROR([Please install go-md2man.])
 fi
+AM_PROG_CC_C_O
 AC_OUTPUT


### PR DESCRIPTION
We need to add AM_PROG_CC_C_O to configure.ac for the RHEL toolchain. Also,
we add -std=gnu99 to the CFLAGS.