### PR TITLE
Make internal functions static, fix prototype for (void) funcs

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,21 +1,7 @@
 include Makefile-docs.am
 libexec_PROGRAMS = registries
 registries_SOURCES = registries.c
-registries_CFLAGS = $(REGISTRIES_DEPS_CFLAGS)
-registries_CFLAGS += -pipe \
-		     -Wall \
-		     -Werror=empty-body \
-		     -Werror=implicit-function-declaration \
-		     -Werror=format=2 -Werror=format-security -Werror=format-nonliteral \
-		     -Werror=pointer-arith -Werror=init-self \
-		     -Werror=return-type \
-		     -Werror=overflow \
-		     -Werror=int-conversion \
-		     -Werror=incompatible-pointer-types \
-		     -Werror=misleading-indentation \
-		     -Werror=missing-include-dirs -Werror=aggregate-return \
-		     -Wextra \
-		     -Werror=unused-result
+registries_CFLAGS = $(AM_CFLAGS) $(WARN_CFLAGS) $(REGISTRIES_DEPS_CFLAGS)
 registries_LDADD = $(REGISTRIES_DEPS_LIBS)
 TESTS = test/test.sh
 

--- a/buildutil/attributes.m4
+++ b/buildutil/attributes.m4
@@ -1,0 +1,292 @@
+dnl Macros to check the presence of generic (non-typed) symbols.
+dnl Copyright (c) 2006-2008 Diego Pettenò <flameeyes@gmail.com>
+dnl Copyright (c) 2006-2008 xine project
+dnl Copyright (c) 2012 Lucas De Marchi <lucas.de.marchi@gmail.com>
+dnl
+dnl This program is free software; you can redistribute it and/or modify
+dnl it under the terms of the GNU General Public License as published by
+dnl the Free Software Foundation; either version 2, or (at your option)
+dnl any later version.
+dnl
+dnl This program is distributed in the hope that it will be useful,
+dnl but WITHOUT ANY WARRANTY; without even the implied warranty of
+dnl MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+dnl GNU General Public License for more details.
+dnl
+dnl You should have received a copy of the GNU General Public License
+dnl along with this program; if not, write to the Free Software
+dnl Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+dnl 02110-1301, USA.
+dnl
+dnl As a special exception, the copyright owners of the
+dnl macro gives unlimited permission to copy, distribute and modify the
+dnl configure scripts that are the output of Autoconf when processing the
+dnl Macro. You need not follow the terms of the GNU General Public
+dnl License when using or distributing such scripts, even though portions
+dnl of the text of the Macro appear in them. The GNU General Public
+dnl License (GPL) does govern all other use of the material that
+dnl constitutes the Autoconf Macro.
+dnl
+dnl This special exception to the GPL applies to versions of the
+dnl Autoconf Macro released by this project. When you make and
+dnl distribute a modified version of the Autoconf Macro, you may extend
+dnl this special exception to the GPL to apply to your modified version as
+dnl well.
+
+dnl Check if FLAG in ENV-VAR is supported by compiler and append it
+dnl to WHERE-TO-APPEND variable. Note that we invert -Wno-* checks to
+dnl -W* as gcc cannot test for negated warnings. If a C snippet is passed,
+dnl use it, otherwise use a simple main() definition that just returns 0.
+dnl CC_CHECK_FLAG_APPEND([WHERE-TO-APPEND], [ENV-VAR], [FLAG], [C-SNIPPET])
+
+AC_DEFUN([CC_CHECK_FLAG_APPEND], [
+  AC_CACHE_CHECK([if $CC supports flag $3 in envvar $2],
+                 AS_TR_SH([cc_cv_$2_$3]),
+          [eval "AS_TR_SH([cc_save_$2])='${$2}'"
+           eval "AS_TR_SH([$2])='${cc_save_$2} -Werror `echo "$3" | sed 's/^-Wno-/-W/'`'"
+           AC_LINK_IFELSE([AC_LANG_SOURCE(ifelse([$4], [],
+                                                 [int main(void) { return 0; } ],
+                                                 [$4]))],
+                          [eval "AS_TR_SH([cc_cv_$2_$3])='yes'"],
+                          [eval "AS_TR_SH([cc_cv_$2_$3])='no'"])
+           eval "AS_TR_SH([$2])='$cc_save_$2'"])
+
+  AS_IF([eval test x$]AS_TR_SH([cc_cv_$2_$3])[ = xyes],
+        [eval "$1='${$1} $3'"])
+])
+
+dnl CC_CHECK_FLAGS_APPEND([WHERE-TO-APPEND], [ENV-VAR], [FLAG1 FLAG2], [C-SNIPPET])
+AC_DEFUN([CC_CHECK_FLAGS_APPEND], [
+  for flag in [$3]; do
+    CC_CHECK_FLAG_APPEND([$1], [$2], $flag, [$4])
+  done
+])
+
+dnl Check if the flag is supported by linker (cacheable)
+dnl CC_CHECK_LDFLAGS([FLAG], [ACTION-IF-FOUND],[ACTION-IF-NOT-FOUND])
+
+AC_DEFUN([CC_CHECK_LDFLAGS], [
+  AC_CACHE_CHECK([if $CC supports $1 flag],
+    AS_TR_SH([cc_cv_ldflags_$1]),
+    [ac_save_LDFLAGS="$LDFLAGS"
+     LDFLAGS="$LDFLAGS $1"
+     AC_LINK_IFELSE([int main() { return 1; }],
+       [eval "AS_TR_SH([cc_cv_ldflags_$1])='yes'"],
+       [eval "AS_TR_SH([cc_cv_ldflags_$1])="])
+     LDFLAGS="$ac_save_LDFLAGS"
+    ])
+
+  AS_IF([eval test x$]AS_TR_SH([cc_cv_ldflags_$1])[ = xyes],
+    [$2], [$3])
+])
+
+dnl define the LDFLAGS_NOUNDEFINED variable with the correct value for
+dnl the current linker to avoid undefined references in a shared object.
+AC_DEFUN([CC_NOUNDEFINED], [
+  dnl We check $host for which systems to enable this for.
+  AC_REQUIRE([AC_CANONICAL_HOST])
+
+  case $host in
+     dnl FreeBSD (et al.) does not complete linking for shared objects when pthreads
+     dnl are requested, as different implementations are present; to avoid problems
+     dnl use -Wl,-z,defs only for those platform not behaving this way.
+     *-freebsd* | *-openbsd*) ;;
+     *)
+        dnl First of all check for the --no-undefined variant of GNU ld. This allows
+        dnl for a much more readable command line, so that people can understand what
+        dnl it does without going to look for what the heck -z defs does.
+        for possible_flags in "-Wl,--no-undefined" "-Wl,-z,defs"; do
+           CC_CHECK_LDFLAGS([$possible_flags], [LDFLAGS_NOUNDEFINED="$possible_flags"])
+           break
+        done
+     ;;
+  esac
+
+  AC_SUBST([LDFLAGS_NOUNDEFINED])
+])
+
+dnl Check for a -Werror flag or equivalent. -Werror is the GCC
+dnl and ICC flag that tells the compiler to treat all the warnings
+dnl as fatal. We usually need this option to make sure that some
+dnl constructs (like attributes) are not simply ignored.
+dnl
+dnl Other compilers don't support -Werror per se, but they support
+dnl an equivalent flag:
+dnl  - Sun Studio compiler supports -errwarn=%all
+AC_DEFUN([CC_CHECK_WERROR], [
+  AC_CACHE_CHECK(
+    [for $CC way to treat warnings as errors],
+    [cc_cv_werror],
+    [CC_CHECK_CFLAGS_SILENT([-Werror], [cc_cv_werror=-Werror],
+      [CC_CHECK_CFLAGS_SILENT([-errwarn=%all], [cc_cv_werror=-errwarn=%all])])
+    ])
+])
+
+AC_DEFUN([CC_CHECK_ATTRIBUTE], [
+  AC_REQUIRE([CC_CHECK_WERROR])
+  AC_CACHE_CHECK([if $CC supports __attribute__(( ifelse([$2], , [$1], [$2]) ))],
+    AS_TR_SH([cc_cv_attribute_$1]),
+    [ac_save_CFLAGS="$CFLAGS"
+     CFLAGS="$CFLAGS $cc_cv_werror"
+     AC_COMPILE_IFELSE([AC_LANG_SOURCE([$3])],
+       [eval "AS_TR_SH([cc_cv_attribute_$1])='yes'"],
+       [eval "AS_TR_SH([cc_cv_attribute_$1])='no'"])
+     CFLAGS="$ac_save_CFLAGS"
+    ])
+
+  AS_IF([eval test x$]AS_TR_SH([cc_cv_attribute_$1])[ = xyes],
+    [AC_DEFINE(
+       AS_TR_CPP([SUPPORT_ATTRIBUTE_$1]), 1,
+         [Define this if the compiler supports __attribute__(( ifelse([$2], , [$1], [$2]) ))]
+         )
+     $4],
+    [$5])
+])
+
+AC_DEFUN([CC_ATTRIBUTE_CONSTRUCTOR], [
+  CC_CHECK_ATTRIBUTE(
+    [constructor],,
+    [void __attribute__((constructor)) ctor() { int a; }],
+    [$1], [$2])
+])
+
+AC_DEFUN([CC_ATTRIBUTE_FORMAT], [
+  CC_CHECK_ATTRIBUTE(
+    [format], [format(printf, n, n)],
+    [void __attribute__((format(printf, 1, 2))) printflike(const char *fmt, ...) { fmt = (void *)0; }],
+    [$1], [$2])
+])
+
+AC_DEFUN([CC_ATTRIBUTE_FORMAT_ARG], [
+  CC_CHECK_ATTRIBUTE(
+    [format_arg], [format_arg(printf)],
+    [char *__attribute__((format_arg(1))) gettextlike(const char *fmt) { fmt = (void *)0; }],
+    [$1], [$2])
+])
+
+AC_DEFUN([CC_ATTRIBUTE_VISIBILITY], [
+  CC_CHECK_ATTRIBUTE(
+    [visibility_$1], [visibility("$1")],
+    [void __attribute__((visibility("$1"))) $1_function() { }],
+    [$2], [$3])
+])
+
+AC_DEFUN([CC_ATTRIBUTE_NONNULL], [
+  CC_CHECK_ATTRIBUTE(
+    [nonnull], [nonnull()],
+    [void __attribute__((nonnull())) some_function(void *foo, void *bar) { foo = (void*)0; bar = (void*)0; }],
+    [$1], [$2])
+])
+
+AC_DEFUN([CC_ATTRIBUTE_UNUSED], [
+  CC_CHECK_ATTRIBUTE(
+    [unused], ,
+    [void some_function(void *foo, __attribute__((unused)) void *bar);],
+    [$1], [$2])
+])
+
+AC_DEFUN([CC_ATTRIBUTE_SENTINEL], [
+  CC_CHECK_ATTRIBUTE(
+    [sentinel], ,
+    [void some_function(void *foo, ...) __attribute__((sentinel));],
+    [$1], [$2])
+])
+
+AC_DEFUN([CC_ATTRIBUTE_DEPRECATED], [
+  CC_CHECK_ATTRIBUTE(
+    [deprecated], ,
+    [void some_function(void *foo, ...) __attribute__((deprecated));],
+    [$1], [$2])
+])
+
+AC_DEFUN([CC_ATTRIBUTE_ALIAS], [
+  CC_CHECK_ATTRIBUTE(
+    [alias], [weak, alias],
+    [void other_function(void *foo) { }
+     void some_function(void *foo) __attribute__((weak, alias("other_function")));],
+    [$1], [$2])
+])
+
+AC_DEFUN([CC_ATTRIBUTE_MALLOC], [
+  CC_CHECK_ATTRIBUTE(
+    [malloc], ,
+    [void * __attribute__((malloc)) my_alloc(int n);],
+    [$1], [$2])
+])
+
+AC_DEFUN([CC_ATTRIBUTE_PACKED], [
+  CC_CHECK_ATTRIBUTE(
+    [packed], ,
+    [struct astructure { char a; int b; long c; void *d; } __attribute__((packed));],
+    [$1], [$2])
+])
+
+AC_DEFUN([CC_ATTRIBUTE_CONST], [
+  CC_CHECK_ATTRIBUTE(
+    [const], ,
+    [int __attribute__((const)) twopow(int n) { return 1 << n; } ],
+    [$1], [$2])
+])
+
+AC_DEFUN([CC_FLAG_VISIBILITY], [
+  AC_REQUIRE([CC_CHECK_WERROR])
+  AC_CACHE_CHECK([if $CC supports -fvisibility=hidden],
+    [cc_cv_flag_visibility],
+    [cc_flag_visibility_save_CFLAGS="$CFLAGS"
+     CFLAGS="$CFLAGS $cc_cv_werror"
+     CC_CHECK_CFLAGS_SILENT([-fvisibility=hidden],
+     cc_cv_flag_visibility='yes',
+     cc_cv_flag_visibility='no')
+     CFLAGS="$cc_flag_visibility_save_CFLAGS"])
+
+  AS_IF([test "x$cc_cv_flag_visibility" = "xyes"],
+    [AC_DEFINE([SUPPORT_FLAG_VISIBILITY], 1,
+       [Define this if the compiler supports the -fvisibility flag])
+     $1],
+    [$2])
+])
+
+AC_DEFUN([CC_FUNC_EXPECT], [
+  AC_REQUIRE([CC_CHECK_WERROR])
+  AC_CACHE_CHECK([if compiler has __builtin_expect function],
+    [cc_cv_func_expect],
+    [ac_save_CFLAGS="$CFLAGS"
+     CFLAGS="$CFLAGS $cc_cv_werror"
+     AC_COMPILE_IFELSE([AC_LANG_SOURCE(
+       [int some_function() {
+        int a = 3;
+        return (int)__builtin_expect(a, 3);
+     }])],
+       [cc_cv_func_expect=yes],
+       [cc_cv_func_expect=no])
+     CFLAGS="$ac_save_CFLAGS"
+    ])
+
+  AS_IF([test "x$cc_cv_func_expect" = "xyes"],
+    [AC_DEFINE([SUPPORT__BUILTIN_EXPECT], 1,
+     [Define this if the compiler supports __builtin_expect() function])
+     $1],
+    [$2])
+])
+
+AC_DEFUN([CC_ATTRIBUTE_ALIGNED], [
+  AC_REQUIRE([CC_CHECK_WERROR])
+  AC_CACHE_CHECK([highest __attribute__ ((aligned ())) supported],
+    [cc_cv_attribute_aligned],
+    [ac_save_CFLAGS="$CFLAGS"
+     CFLAGS="$CFLAGS $cc_cv_werror"
+     for cc_attribute_align_try in 64 32 16 8 4 2; do
+        AC_COMPILE_IFELSE([AC_LANG_SOURCE([
+          int main() {
+            static char c __attribute__ ((aligned($cc_attribute_align_try))) = 0;
+            return c;
+          }])], [cc_cv_attribute_aligned=$cc_attribute_align_try; break])
+     done
+     CFLAGS="$ac_save_CFLAGS"
+  ])
+
+  if test "x$cc_cv_attribute_aligned" != "x"; then
+     AC_DEFINE_UNQUOTED([ATTRIBUTE_ALIGNED_MAX], [$cc_cv_attribute_aligned],
+       [Define the highest alignment supported])
+  fi
+])

--- a/configure.ac
+++ b/configure.ac
@@ -3,12 +3,38 @@ AC_CONFIG_HEADER([config.h])
 AC_CONFIG_SRCDIR([registries.c])
 
 AC_CONFIG_AUX_DIR([build])
+AC_CONFIG_MACRO_DIR([buildutil])
 
-AM_INIT_AUTOMAKE([-Wall -Werror foreign])
+AM_INIT_AUTOMAKE([1.13 -Wno-portability foreign no-define tar-ustar no-dist-gzip dist-xz
+                  color-tests subdir-objects])
+AC_USE_SYSTEM_EXTENSIONS
+AC_SYS_LARGEFILE
 
 # Check for C compiler
 AC_PROG_CC
-AC_CONFIG_FILES([Makefile])
+AM_PROG_CC_C_O
+
+dnl The canonical version of this is in libostree
+CC_CHECK_FLAGS_APPEND([WARN_CFLAGS], [CFLAGS], [\
+-pipe \
+-Wall \
+-Werror=empty-body \
+-Werror=strict-prototypes \
+-Werror=missing-prototypes \
+-Werror=implicit-function-declaration \
+"-Werror=format=2 -Werror=format-security -Werror=format-nonliteral" \
+-Werror=pointer-arith -Werror=init-self \
+-Werror=missing-declarations \
+-Werror=return-type \
+-Werror=overflow \
+-Werror=int-conversion \
+-Werror=parenthesis \
+-Werror=incompatible-pointer-types \
+-Werror=misleading-indentation \
+-Werror=missing-include-dirs -Werror=aggregate-return \
+-Werror=unused-result \
+])
+AC_SUBST(WARN_CFLAGS)
 
 PKG_PROG_PKG_CONFIG
 PKG_CHECK_MODULES([REGISTRIES_DEPS], [gio-2.0 json-glib-1.0 yaml-0.1])
@@ -17,5 +43,5 @@ if test x"$GO_MD2MAN_CHECK" != x"yes" ; then
     AC_MSG_ERROR([Please install go-md2man.])
 fi
 
-AM_PROG_CC_C_O
+AC_CONFIG_FILES([Makefile])
 AC_OUTPUT

--- a/registries.c
+++ b/registries.c
@@ -13,17 +13,16 @@
 #include <unistd.h>
 #include <json-glib/json-glib.h>
 
-GArray *registries;
-GHashTable* hash;
-GPtrArray* tmp_values;
-char * headers [] = { "registries", "insecure_registries", "block_registries" };
-gchar *cur_header = "None";
+static GHashTable* hash;
+static GPtrArray* tmp_values;
+static char * headers [] = { "registries", "insecure_registries", "block_registries" };
+static gchar *cur_header = "None";
 
 /*
  * Check if registries are still being exported from
  * sysconfig
  */
-void check_envs(){
+static void check_envs(void){
 	char *env_variables[] = {
 			"ADD_REGISTRY",
 			"INSECURE_REGISTRY",
@@ -46,14 +45,14 @@ void check_envs(){
 /*
  * Add  a single value to the tmp_array
  */
-void add_value_to_tmp_array(char* value){
+static void add_value_to_tmp_array(char* value){
 	g_ptr_array_add(tmp_values, g_strdup(value));
 }
 
 /*
  * Destroy the temporary array and recreate blank
  */
-void destroy_tmp_array(){
+static void destroy_tmp_array(void){
 	g_ptr_array_free(tmp_values, TRUE);
 	tmp_values = g_ptr_array_new();
 }
@@ -63,7 +62,7 @@ void destroy_tmp_array(){
  *
  * Returns: bool
  */
-bool is_string_header(char* header)
+static bool is_string_header(char* header)
 {
 	size_t i;
 	for (i=0; i < sizeof(headers)/sizeof(headers[0]); i++ ) {
@@ -78,7 +77,7 @@ bool is_string_header(char* header)
  * Iterates the tmp_array values and adds them to a new
  * NULL terminated ptr_array
  */
-GPtrArray* assemble_array(){
+static GPtrArray* assemble_array(void){
 	GPtrArray* store_values = g_ptr_array_new();
 	for (guint i = 0; i < tmp_values->len; i++) {
 		g_ptr_array_add(store_values, g_ptr_array_index(tmp_values, i));
@@ -91,7 +90,7 @@ GPtrArray* assemble_array(){
 /*
  * Iterates (recursively if needed) the YAML "tree" from the parser
  */
-void print_yaml_node(yaml_document_t *document_p, yaml_node_t *node, bool header)
+static void print_yaml_node(yaml_document_t *document_p, yaml_node_t *node, bool header)
 {
 	char* heading;
 	switch(node->type){
@@ -152,7 +151,7 @@ void print_yaml_node(yaml_document_t *document_p, yaml_node_t *node, bool header
  *
  * Returns: gchar*
  */
-gchar* get_switch_from_header(char *header) {
+static gchar* get_switch_from_header(char *header) {
 	gchar* ret = NULL;
 	if (g_strcmp0 ("registries", header) == 0) {
 		ret = " --add-registry ";
@@ -171,7 +170,7 @@ gchar* get_switch_from_header(char *header) {
  *
  * Returns: gchar*
  */
-gchar* build_string(){
+static gchar* build_string(void){
 	gchar *output = "";
 	// Build hash lookup
 	GList *keys;
@@ -192,7 +191,7 @@ gchar* build_string(){
  *
  * Returns: gchar*
  */
-gchar* build_json() {
+static gchar* build_json(void) {
 
 	GList *keys;
 	JsonBuilder *builder = json_builder_new ();
@@ -233,7 +232,7 @@ gchar* build_json() {
 /*
  * Ensures we the input file exists and we can read it
  */
-void check_file(gchar *file_name){
+static void check_file(gchar *file_name){
 	if (access(file_name, F_OK) == -1){
 		fprintf(stderr, "%s does not exist\n", file_name);
 		exit (1);
@@ -252,7 +251,7 @@ void check_file(gchar *file_name){
  *
  * output_variable="output"
  */
-void write_to_file(gchar *output, gchar *output_file, gchar *output_variable){
+static void write_to_file(gchar *output, gchar *output_file, gchar *output_variable){
 	if (access(g_path_get_dirname(output_file), W_OK) != 0) {
 		fprintf(stderr, "Unable to write the file %s\n", output_file);
 		exit (1);


### PR DESCRIPTION
In C, `()` means `(int)` by default, change the functions to use
`(void)`.

Also, all of these functions and data members should be static,
since they're internal only.

Copy the `attributes.m4` that came from systemd (which came from
some Gentoo project) and use it to detect the compiler-supported
warnings.