### PR TITLE
ci: rename file to new name and bump to f26

### DIFF
--- a/.papr.yml
+++ b/.papr.yml
@@ -4,9 +4,9 @@ branches:
   - try
 
 container:
-    image: registry.fedoraproject.org/fedora:25
+  image: registry.fedoraproject.org/fedora:26
 
-context: 'f25-build-check'
+context: 'f26-build-check'
 required: true
 
 # Build with deps


### PR DESCRIPTION
Rename the YAML file and its auxiliary files to the newly supported
name. Bump tests to use f26.