### PR TITLE
registries_migrator: Correct typo and imports

### DIFF
--- a/.papr.yml
+++ b/.papr.yml
@@ -17,6 +17,7 @@ packages:
     - bats
 
 tests:
+    - make install DESTDIR=/
     - make test
 
 artifacts:

--- a/registries/registries_migrator.py
+++ b/registries/registries_migrator.py
@@ -1,4 +1,4 @@
-from registries import loadYAML
+from registries.registries import loadYAML
 import pytoml
 import argparse
 import sys

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setuptools.setup(
     entry_points={
         'console_scripts': [
             'registries = registries.registries:registries',
-            'registries_migrator = registries.registries:migrate'
+            'registries_migrator = registries.registries_migrator:migrate'
         ]
     }
 )

--- a/test/test.bats
+++ b/test/test.bats
@@ -4,8 +4,8 @@ TEST=1
 PYTHON=${PYTHON:-/usr/bin/python3}
 PWD=$(pwd)
 TEST_DIR="${PWD}/test"
-BINARY="${PWD}/registries/registries.py"
-MIGRATOR="${PWD}/registries/registries_migrator.py"
+BINARY="/usr/libexec/registries"
+MIGRATOR="/usr/libexec/registries_migrator"
 
 STR_RESULT[0]='--add-registry registry1 --insecure-registry registry2 --block-registry registry3 '
 JSON_RESULT[0]='{"registries.search": {"registries": ["registry1"]}, "registries.insecure": {"registries": ["registry2"]}, "registries.block": {"registries": ["registry3"]}}'


### PR DESCRIPTION
An import was incorrect for system usage as it was not
"fully-qualified".  Also the console script section of
setup has a typo in its module "path".

Signed-off-by: baude <bbaude@redhat.com>