### PR TITLE
registries/registries.py: Create output dir

### DIFF
--- a/registries/registries.py
+++ b/registries/registries.py
@@ -31,6 +31,9 @@ map_output = {
 
 
 def write_file(filename, data):
+    dir_path = os.path.dirname(filename)
+    if not os.path.exists(dir_path):
+        os.makedirs(dir_path)
     with open(filename,"w") as f:
         f.write(data)
 


### PR DESCRIPTION
If the output file name includes directories that do not exist,
we need to create them.  Specifically the registries service
file wants to write to /run/containers/.