### PR TITLE
Add test for quoted toml

### DIFF
--- a/test/test.bats
+++ b/test/test.bats
@@ -250,3 +250,10 @@ registries = []'
 	echo "$output"
 	[ "$output" = "$RESULT" ]
 }
+
+# Quoted TOML Test
+@test "quoted toml test" {
+	run "$PYTHON" "$BINARY" -i "$TEST_DIR/test98.toml"
+    RESULT='--add-registry registry1 --insecure-registry registry2 --block-registry registry3 '
+	[ "$output" = "$RESULT" ]
+}

--- a/test/test98.toml
+++ b/test/test98.toml
@@ -1,0 +1,8 @@
+["registries.search"]
+registries = ['registry1']
+
+["registries.insecure"]
+registries = ['registry2']
+
+["registries.block"]
+registries = ['registry3']


### PR DESCRIPTION
Make sure that the categories if quoted in TOML
still act properly

Signed-off-by: baude <bbaude@redhat.com>