### PR TITLE
Add -o|--output to registries_migrator

### DIFF
--- a/docs/registries.1.md
+++ b/docs/registries.1.md
@@ -74,10 +74,10 @@ The initial registries.conf files were based on a YAML structure.  This version 
 still supports reading YAML.  However, you should preferably migrate the YAML to TOML.
 To do this, make a back up copy of `/etc/containers/registries.conf`.  Then run the
 registries_migrator tool which will output in the TOML format.  Verify the output
-looks correct and then pipe it to `/etc/containers/registries.conf`.  For example:
+looks correct and then write it to `/etc/containers/registries.conf` with the -o switch.  For example:
 
 ```
-# /usr/libexec/registries_migrator > /etc/containers/registries.conf
+# /usr/libexec/registries_migrator -o  /etc/containers/registries.conf
 
 ```
 

--- a/registries/registries.py
+++ b/registries/registries.py
@@ -20,7 +20,7 @@ def log_warning(conf_file):
         handler.setFormatter(formatter)
         log.addHandler(handler)
         log.warning("{} is in YAML format and should be in TOML format. Back this file up and then "
-                    "use /usr/libexec/registries_migrator > /etc/containers/registries.conf to "
+                    "use /usr/libexec/registries_migrator -o /etc/containers/registries.conf to "
                     "convert it to TOML.".format(conf_file))
 
 map_output = {

--- a/registries/registries_migrator.py
+++ b/registries/registries_migrator.py
@@ -4,15 +4,21 @@ import argparse
 import sys
 
 
-def _migrate(registries_conf_file):
-    sys.stdout.write(pytoml.dumps(loadYAML.get_registries(registries_conf_file)))
+def _migrate(registries_conf_file, output_file):
+    toml = pytoml.dumps(loadYAML.get_registries(registries_conf_file))
+    if output_file:
+        with open(output_file,"w") as f:
+            f.write(toml)
+    else:
+        print(toml)
 
 
 def migrate():
     parser = argparse.ArgumentParser(description="Migrate registries.conf from YAML to TOML")
     parser.add_argument("-i", "--input", help="Specify an input file", default="/etc/containers/registries.conf")
+    parser.add_argument("-o", "--output", help="Specify an output file")
     args = parser.parse_args()
-    _migrate(args.input)
+    _migrate(args.input, args.output)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
When piping over the original file you are migrating, the data
would be incorrect.  Adding an ouput option to the tool allows
the user to specify an output file instead of piping.

Signed-off-by: baude <bbaude@redhat.com>